### PR TITLE
fix when column A has null value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,13 +100,11 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
     await this.initCheck();
     const opt = {
       spreadsheetId: this.options.spreadsheetID,
-      range: `${this.getSheetRange()}A1:A`,
+      range: `${this.getSheetRange()}A1:Z`,
     };
 
     const data = await this.gsapi!.spreadsheets.values.get(opt);
-    const nonEmptyRows = (data.data.values || []).filter(
-      (row) => row[0] !== '',
-    ).length;
+    const nonEmptyRows = (data.data.values || []).length;
 
     return nonEmptyRows;
   }


### PR DESCRIPTION
There is a situation where column A may not have a value, but column B does. In this scenario, you will get the wrong record count. In this example, you will get a record count of 2 instead of 3:

| A | B |
| -------- | ------- |
| user1 | mail1 |
| user2 | mail2 |
| | mailwithoutuser |

I changed the range so that it fetches columns A:Z instead of just A and I removed the filter that was only checking values in column A. Google sheets appears to only gives rows that have data within the row, so the filter is not necessary.