### PR TITLE
fix 2 delete bugs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -273,26 +273,28 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
   public async deleteRowByIndex(index: number | number[]) {
     await this.initCheck();
     const _indexes = Array.isArray(index) ? index : [index];
+
+    if (_indexes.length === 0) {
+      return null;
+    }
+
     const sheetID = await this.getSheetID();
 
-    const first = _indexes[0];
-    const last = _indexes[_indexes.length - 1] + 1;
+    const deleteDimensions = _indexes.map((index) => ({
+      deleteDimension: {
+        range: {
+          sheetId: sheetID,
+          dimension: "ROWS",
+          startIndex: index,
+          endIndex: index + 1,
+        },
+      },
+    }));
 
     const result = await this.gsapi!.spreadsheets.batchUpdate({
       spreadsheetId: this.options.spreadsheetID,
       requestBody: {
-        requests: [
-          {
-            deleteDimension: {
-              range: {
-                sheetId: sheetID,
-                dimension: 'ROWS',
-                startIndex: first,
-                endIndex: last,
-              },
-            },
-          },
-        ],
+        requests: deleteDimensions,
       },
     });
     return result;


### PR DESCRIPTION
This fixes 2 delete bugs:
1. If you do a delete with a filter and there are no filter results and no records to delete the delete would give an error
2. I think the logic was assuming that the `index` parameter was a contiguous array of indices. This is not usually the case. You might have an index like: `[1, 3, 5]`. It would previously delete rows 1-5 instead of 1, 3, 5.