### PR TITLE
Added sheetname to create and rev sort for delete

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -276,6 +276,9 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
       return null;
     }
 
+    _indexes.sort();
+    _indexes.reverse();
+
     const sheetID = await this.getSheetID();
 
     const deleteDimensions = _indexes.map((index) => ({
@@ -332,7 +335,7 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
     await this.gsapi!.spreadsheets.values.append({
       spreadsheetId: this.options.spreadsheetID,
       valueInputOption: 'USER_ENTERED',
-      range: 'A1:A',
+      range: `${this.getSheetRange()}A1:A`,
       requestBody: {
         values: [values], // [ [ "Avalue", "Bvalue", "Cvalue"... ] ]
       },


### PR DESCRIPTION
I got the tests setup and the issue was because it was batch deleting: row1, row2, row3... in increasing order. If we delete row1, then row2 becomes row1. So effectively, we end up only deleting row1 and row3.
To fix this, I sorted the indexes in decreasing order before deleting.

Also fixed a bug where the sheetname wasn't specified during `create`