### PR TITLE
Fix issue when updating an existing row with a last column that's empty/undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,10 @@ import {
 } from './types/table';
 
 export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
-  private client: JWT | null = null;
+  private readonly client: JWT | null = null;
   private initiated = false;
   private gsapi: ReturnType<typeof google.sheets> | null = null;
-  private __invertedScheme: Record<Values<T>, Field>;
+  private readonly __invertedScheme: Record<Values<T>, Field>;
 
   constructor(
     /**
@@ -193,9 +193,11 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
     rows: RowValues<T>[],
     updateData: Partial<Record<Values<T>, Field>>,
   ): UpdatableData {
-    return rows.reduce((acc, row) => {
+    const updatableD = rows.reduce((acc, row) => {
       const rowIndex = row.__tableRowIndex;
-      const keys = Object.keys(row).filter((k) => k !== '__tableRowIndex');
+      const keys = Object.keys(this.__invertedScheme).filter(
+        (k) => k !== '__tableRowIndex',
+      );
       keys
         // @ts-expect-error keys are exists
         .map((k) => [`${this.__invertedScheme[k]}${rowIndex}`, updateData[k]])
@@ -204,6 +206,8 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
         });
       return acc;
     }, {} as UpdatableData);
+
+    return updatableD;
   }
 
   private filterData(
@@ -285,7 +289,7 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
       deleteDimension: {
         range: {
           sheetId: sheetID,
-          dimension: "ROWS",
+          dimension: 'ROWS',
           startIndex: index,
           endIndex: index + 1,
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
   private initiated = false;
   private gsapi: ReturnType<typeof google.sheets> | null = null;
   private readonly __invertedScheme: Record<Values<T>, Field>;
+  private readonly __schemaKeys: string[];
 
   constructor(
     /**
@@ -59,6 +60,9 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
       acc[this.scheme[k as keyof typeof this.scheme]] = k;
       return acc;
     }, {} as Record<Values<T>, Field>);
+    this.__schemaKeys = Object.keys(this.__invertedScheme).filter(
+      (key) => key !== '__tableRowIndex',
+    );
     this.client = new google.auth.JWT(
       this.options.email,
       undefined,
@@ -195,10 +199,7 @@ export class Table<const T extends Partial<Record<Columns, Field>> = {}> {
   ): UpdatableData {
     const updatableD = rows.reduce((acc, row) => {
       const rowIndex = row.__tableRowIndex;
-      const keys = Object.keys(this.__invertedScheme).filter(
-        (k) => k !== '__tableRowIndex',
-      );
-      keys
+      this.__schemaKeys
         // @ts-expect-error keys are exists
         .map((k) => [`${this.__invertedScheme[k]}${rowIndex}`, updateData[k]])
         .forEach((kv) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,10 @@
 {
-  "include": [
-    "src/*"],
-  "exclude": [
-    "src/**/*.test.ts"
-  ],
+  "include": ["src/*"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
     /* Projects */
-    "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    "incremental": true /* Save .tsbuildinfo files to allow for incremental compilation of projects. */,
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
     // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
@@ -16,7 +12,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "ES2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -35,7 +31,7 @@
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "baseUrl": "./",
     "paths": {
-      "@src/*": ["src/*"],
+      "@src/*": ["src/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
@@ -55,12 +51,12 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    "outDir": "./build",                                   /* Specify an output folder for all emitted files. */
-    "removeComments": true,                           /* Disable emitting comments. */
+    "outDir": "./build" /* Specify an output folder for all emitted files. */,
+    "removeComments": true /* Disable emitting comments. */,
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
@@ -80,19 +76,19 @@
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
+    "strictNullChecks": true /* When type checking, take into account 'null' and 'undefined'. */,
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    "noImplicitThis": true /* Enable error reporting when 'this' is given the type 'any'. */,
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
@@ -107,7 +103,7 @@
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
     /* Completeness */
-    "skipDefaultLibCheck": false,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": false                                 /* Skip type checking all .d.ts files. */
+    "skipDefaultLibCheck": false /* Skip type checking .d.ts files that are included with TypeScript. */,
+    "skipLibCheck": false /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
I noticed if I have a schema like:

```ts
const scheme = { A: 'id', B: 'username', C: 'email', D: 'last_col' } as const;
```

And my sheet looks like:
| A | B | C | D |
|--------|--------|--------|--------|
| 1 | username | email@test | |
| 2 |  | email@test | blah | 

If I try to update col D where `id` = 1
```ts
    await usersTable.update({
      where: {
        email: 'email@test',
      },
      data: {
        last_col: 'UPDATED',
      },
    });
```

The column never get's updated. The reason is when `usersTable.read()` is called, it converts the array of arrays to an array of objects. When creating the object, the last value doesn't exist so the column name form the schema never actually get's added to that row.

So when creating the UpdatableData, I get the keys of the `this.__invertedSchema`.

Let me know what you think or if you have any suggestions.